### PR TITLE
SSL recognition added. ServiceGroup function added

### DIFF
--- a/nsnitro/nsnitro.py
+++ b/nsnitro/nsnitro.py
@@ -20,12 +20,12 @@ class NSNitro:
         __contenttype = "application/x-www-form-urlencoded"
         __postheaders = {'Cookie' : 'sessionid='+__sessionid, 'Content-type' : __contenttype}
 
-        def __init__(self, ip, user, password):
+        def __init__(self, ip, user, password, useSSL):
                 """ Contructor: ip - LB ip, user - LB username, pass - LB password """
                 self.__ip = ip
                 self.__user = user
                 self.__password = password
-                self.__baseurl = "http://%s/nitro/v1/config/" % ip
+                self.__baseurl = "%s://%s/nitro/v1/config/" % ('https' if useSSL else 'http',ip)
                 self.__initialized = True
 
         def get_url(self):

--- a/nsnitro/nsresources/nsservicegroup.py
+++ b/nsnitro/nsresources/nsservicegroup.py
@@ -396,6 +396,18 @@ class NSServiceGroup(NSBaseResource):
         return __servicegroups
     
     @staticmethod
+    def get_servers(nitro, servicegroup):
+        """
+        Use this API to fetch all configured servicegroup members.
+        """
+        __url = nitro.get_url() + 'servicegroup_servicegroupmember_binding' + '/' + servicegroup.get_servicegroupname()
+        __json_services = nitro.get(__url).get_response_field('servicegroup_servicegroupmember_binding')
+        __servicegroupmembers = []
+        for json_service in __json_services:
+            __servicegroupmembers.append(NSServiceGroup(json_service))
+        return __servicegroupmembers
+
+    @staticmethod
     def add(nitro, servicegroup):
         """
         Use this API to add service.


### PR DESCRIPTION
Added get_servers() to nsservicegroup.py for getting a list of all servers within the service group

Modified the def **init** in nsnitro.py to do the following:

Original:
    def **init**(self, ip, user, password):
Updated:
    def **init**(self, ip, user, password, useSSL):

This allows the selection of the SSL https for accessing the URL or not.

Within the **init**:

Original:
    self.__baseurl = "http://%s/nitro/v1/config/" % ip
Updated:
    self.__baseurl = "%s://%s/nitro/v1/config/" % ('https' if useSSL else 'http',ip)

This chooses between the http versus https depending on the True/False value of useSSL set in the **init** function for the NSNitro class.
