### PR TITLE
Get method is broken for rewrite policies

### DIFF
--- a/nsnitro/nsresources/nsrewritepolicy.py
+++ b/nsnitro/nsresources/nsrewritepolicy.py
@@ -183,7 +183,7 @@ class NSRewritePolicy(NSBaseResource):
                 Use this API to fetch rewritepolicy resource of given name.
                 """
                 __rewritepolicy = NSRewritePolicy()
-                __rewritepolicy.set_name(rewritepolicy.get_policyname())
+                __rewritepolicy.set_name(rewritepolicy.get_name())
                 __rewritepolicy.get_resource(nitro)
                 return __rewritepolicy
 


### PR DESCRIPTION
Calls to NSRewritePolicy.get cause the following trace.  This replaces the call to get_policyname with get_name.

Traceback (most recent call last):
  File "nitro.py", line 15, in <module>
    arg = NSRewritePolicy.get(nitro, pol)
  File "./nsnitro/nsresources/nsrewritepolicy.py", line 186, in get
    __rewritepolicy.set_name(rewritepolicy.get_policyname())
AttributeError: 'NSRewritePolicy' object has no attribute 'get_policyname'
