### PR TITLE
Return an empty array if a field is missing in the json response

### DIFF
--- a/nsnitro/nsutil.py
+++ b/nsnitro/nsutil.py
@@ -39,5 +39,8 @@ class NSNitroResponse:
 
         def get_response_field(self, field_name):
                 """ Returns field_name of parsed JSON dictionary """
-                return self.__jresponse[field_name]
+                if field_name in self.__jresponse:
+                    return self.__jresponse[field_name]
+                else:
+                    return []
 


### PR DESCRIPTION
Empty sets are not always in the json response (such as no bindings) and a
KeyError is raised.
