### PR TITLE
Added method to explicitly save running configuration

### DIFF
--- a/nsnitro/nsnitro.py
+++ b/nsnitro/nsnitro.py
@@ -127,3 +127,21 @@ class NSNitro:
 
                 except NSNitroError, e:
                     raise NSNitroError(nsresponse.message)
+
+        def save(self):
+                """ Saves running configuration """
+                payload = {
+                    "object": json.dumps(
+                        {
+                            "params": {"action": "save"},
+                            "nsconfig": {},
+                        }
+                    )
+                }
+                try:
+                    nsresponse = self.post(payload)
+                    return nsresponse.get_json_response()
+
+                except NSNitroError, e:
+                    raise NSNitroError(nsresponse.message)
+


### PR DESCRIPTION
All configuration happens in memory. If Netscaler device is restarted, all configuration made to it is lost. This patch introduces new method that allows saving running configuration.
