### PR TITLE
Fix: getter for cipherurl and nsip single resource get

### DIFF
--- a/nsnitro/nsresources/nsip.py
+++ b/nsnitro/nsresources/nsip.py
@@ -311,6 +311,11 @@ class NSIP(NSBaseResource):
                 return __ip.perform_operation(nitro, "disable")
 
         @staticmethod
+        def get(nitro, ip):
+                __url = nitro.get_url() + NSIP.get_resourcetype() + "/" + ip.get_ipaddress()
+                return nitro.get(__url).get_response_field(NSIP.get_resourcetype())[0]
+
+        @staticmethod
         def get_all(nitro):
                 """
                 Use this API to fetch all nsip resources that are configured on netscaler.

--- a/nsnitro/nsresources/nssslvserver.py
+++ b/nsnitro/nsresources/nssslvserver.py
@@ -237,7 +237,7 @@ class NSSSLVServer(NSBaseResource):
                 """
                 self.options['cipherurl'] = cipherurl
 
-        def get_cipherurl(self, cipherurl):
+        def get_cipherurl(self):
                 """
                 The redirect URL to be used with the Cipher Redirect feature.
                 """


### PR DESCRIPTION
Fix the getter in nssslvserver for cipherurl which was created incorrectly. 
Add single ns ip object get
