### PR TITLE
rename badly named get method

### DIFF
--- a/nsnitro/nsresources/nslbmonitor.py
+++ b/nsnitro/nsresources/nslbmonitor.py
@@ -352,7 +352,7 @@ class NSLBMonitor(NSBaseResource):
                 Use this API to fetch LB Monitor of given name.
                 """
                 __monitor = NSLBMonitor()
-                __monitor.set_name(monitor.get_name())
+                __monitor.set_monitorname(monitor.get_monitorname())
                 __monitor.get_resource(nitro)
                 return __monitor
 

--- a/nsnitro/nsresources/nslbmonitor.py
+++ b/nsnitro/nsresources/nslbmonitor.py
@@ -11,6 +11,7 @@ class NSLBMonitor(NSBaseResource):
                 """
                 super(NSLBMonitor, self).__init__()
                 self.options = {'monitorname': '',
+                                'name': '',
                                 'alertretries': '',
                                 'destport': '',
                                 'deviation': '',
@@ -72,6 +73,7 @@ class NSLBMonitor(NSBaseResource):
 
         def set_monitorname(self, monitorname):
                 self.options['monitorname'] = monitorname
+                self.options['name'] = monitorname
 
         def get_monitorname(self):
                 return self.options['monitorname']


### PR DESCRIPTION
replaced get_name() by get_monitorname() in get() methode
