### PR TITLE
Remove namespace_packages line from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     license = "GPL",
     keywords = "citrix netscaler nitro api nsnitro",
     url = "http://pypi.python.org/pypi/nsnitro",
-    namespace_packages = ["nsnitro"],
     packages=["nsnitro"] + [os.path.join("nsnitro",a) for a in find_packages("nsnitro")],
     long_description=read('README'),
     classifiers=[


### PR DESCRIPTION
By making nsnitro a namespace package, pip installation ignores **init**.py, which means importing the module doesn't work as described in the examples. Remove the namespace_packages line as it doesn't add any value.

Existing import behaviour (e.g. `from nsnitro.nsnitro import *` is preserved, while also allowing the documented `from nsnitro import *`, or simply `import nsnitro`.

This closes issue #67.
