### PR TITLE
Netscaler 10.1 and 9.3 inconsistency for nshostname

### DIFF
--- a/nsnitro/nsresources/nshostname.py
+++ b/nsnitro/nsresources/nshostname.py
@@ -33,4 +33,6 @@ class NSHostname(NSBaseResource):
         def get(nitro):
             __url = nitro.get_url() + NSHostname.get_resourcetype()
             __json_nshostname = nitro.get(__url).get_response_field(NSHostname.get_resourcetype())
+            if isinstance(__json_nshostname, list):
+                    return NSHostname(__json_nshostname[0])
             return NSHostname(__json_nshostname)


### PR DESCRIPTION
10.1 and 9.3 handle nshostname differently. This is a fix for that.

Output from NetScaler NS10.1: Build 112.13.nc:
{ "errorcode": 0, "message": "Done", "severity": "NONE", "nshostname": [ { "hostname": "blah" } ] }

Output from NetScaler NS9.3: Build 61.59.nc:
{ "errorcode": 0, "message": "Done", "nshostname": { "hostname": "blah" } }
