### PR TITLE
Fix: Correctly handle cipheader in NSService

### DIFF
--- a/nsnitro/nsresources/nsservice.py
+++ b/nsnitro/nsresources/nsservice.py
@@ -558,7 +558,7 @@ class NSService(NSBaseResource):
         Default value: 0
         Minimum length =  1.
         """
-        return self.options['cip']
+        return self.options['cipheader']
 
     def set_cipheader(self, cipheader):
         """


### PR DESCRIPTION
Correctly handle cipheader in NSService
