### PR TITLE
Fix get() method of NSCSPolicy

### DIFF
--- a/nsnitro/nsresources/nscspolicy.py
+++ b/nsnitro/nsresources/nscspolicy.py
@@ -192,7 +192,7 @@ class NSCSPolicy(NSBaseResource):
         """
         __cspolicy = NSCSPolicy()
         __cspolicy.set_policyname(cspolicy.get_policyname())
-        __cspolicy.get_resource(nitro)
+        __cspolicy.get_resource(nitro, cspolicy.get_policyname())
         return __cspolicy
 
     @staticmethod


### PR DESCRIPTION
The get_resource() method in NSBaseResource is expecting the 'name' option to be populated and uses that value to build the query URL.  This update explicitly passes the policyname value to the get_resource() method to return a correct result.
