### PR TITLE
Add get_lbvserver to nscsvserver

### DIFF
--- a/nsnitro/nsresources/nscsvserver.py
+++ b/nsnitro/nsresources/nscsvserver.py
@@ -78,7 +78,8 @@ class NSCSVServer(NSBaseResource):
                         'gt2gb': '',
                         'statechangetimesec': '',
                         'statechangetimemsec': '',
-                        'tickssincelaststatechange': ''}
+                        'tickssincelaststatechange': '',
+                        'lbvserver': ''}
 
         self.resourcetype = NSCSVServer.get_resourcetype()
 
@@ -1001,6 +1002,12 @@ class NSCSVServer(NSBaseResource):
         Default value: 0
         """
         return self.options['tickssincelaststatechange']
+
+    def get_lbvserver(self):
+        """
+        Name of the default lb vserver bound.
+        """
+        return self.options['lbvserver']
 
     # Operations methods
     @staticmethod


### PR DESCRIPTION
In older netscaler versions one could get away with polling prio 0 policy binding for obtaining the default policy and thus default lb for a given cs vserver. Prio 0 has been long deprecated, however, obtaining the default 'lbvserver' value was still missing from this nsnitro project.
