### PR TITLE
Fix call for getprimarylb

### DIFF
--- a/bin/nsnitrocmd.py
+++ b/bin/nsnitrocmd.py
@@ -61,7 +61,7 @@ def get_mappings(args):
         return type_map['class_name'], type_map['state_function'], type_map['up_state']
 
 
-def action_getprimarylb(args):
+def action_getprimarylb(args, nitro):
         ha_node = NSHANode()
         for node in ha_node.get_all(nitro):
                 state = node.get_state().lower()
@@ -440,7 +440,8 @@ if __name__ == "__main__":
                 sys.exit(2)
         try:
                 result = args.func(args, nitro)
-                print result
+                if not result == None:
+                        print result
         finally:
                 nitro.logout()
                 if result is None:


### PR DESCRIPTION
the function call for args.func has two params, but the def for getprimarylb only has one, so added 'args' to the list so the call won't fail. also cleanup the output of result so it only output when not empty.
